### PR TITLE
Add ability to install poetry without installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Optionally can export dependency tree to requirements.txt file.
     If value is 'all', all extras will be installed
   - install_only_dependencies -- If set to true, installs only dependencies for project, adds the parameter
     `--no-root` to `poetry install` command. **Optional**. Default is '**false**'"
+  - skip_dependencies -- If set to true, installs only poetry without installing dependencies. **Optional**. Default is '**false**'"
 
 ### Outputs
 No outputs defined

--- a/install_poetry/action.yaml
+++ b/install_poetry/action.yaml
@@ -63,6 +63,12 @@ inputs:
     required: false
     default: "false"
 
+  skip_dependencies:
+    description: |
+      If set to true, installs only poetry without installing dependencies
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -79,4 +85,5 @@ runs:
         EXPORT_CREDENTIALS: ${{ inputs.export_credentials }}
         EXTRAS: ${{ inputs.install_extras }}
         INSTALL_NO_ROOT: ${{ inputs.install_only_dependencies }}
+        SKIP_DEPENDENCIES: ${{ inputs.skip_dependencies}}
       run: $GITHUB_ACTION_PATH/install_poetry.sh

--- a/install_poetry/install_poetry.sh
+++ b/install_poetry/install_poetry.sh
@@ -44,7 +44,12 @@ if [[ "$(echo "$INSTALL_NO_ROOT" | tr '[:upper:]' '[:lower:]')" == 'true' ]]; th
   POETRY_ADDITIONAL_OPTIONS+=("--no-root")
 fi;
 
-poetry install "${POETRY_ADDITIONAL_OPTIONS[@]}"
+if [[ "$(echo "$SKIP_DEPENDENCIES" | tr '[:upper:]' '[:lower:]')" == 'false' ]]; then
+    echo "Install dependencies"
+    poetry install "${POETRY_ADDITIONAL_OPTIONS[@]}"
+  else
+  echo "Install dependencies skipped because SKIP_DEPENDENCIES is set to \"$SKIP_DEPENDENCIES\""
+fi;
 
 EXPORT_ADDITIONAL_OPTIONS=""
 if [[ "$(echo "$EXPORT_CREDENTIALS" | tr '[:upper:]' '[:lower:]')" == "true" ]];


### PR DESCRIPTION
Add ability to install Poetry without installing dependencies. It's required for release workflows, where Poetry is needed only for running the "poetry publish" command.