### PR TITLE
Add ability to set expiration date from workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,17 +515,16 @@ Generates new temporary
 for a file share, attached to a storage account.
 
 ### Inputs
-| Name            | Description                                                  | Optional | Default Value |
-|-----------------|:-------------------------------------------------------------|----------|---------------|
-| directory_name  | Path within file share                                       | False    |               |
-| account_key     | Name of the storage account of the share                     | False    |               |
-| account_name    | Key of the storage account of the share                      | False    |               |
-| expiration_date | Expiration date in format that can be used by `date` command | True     | +10 minutes   |
+| Name            | Description                                                      | Optional | Default Value |
+|-----------------|:-----------------------------------------------------------------|----------|---------------|
+| directory_name  | Path within file share                                           | False    |               |
+| account_key     | Name of the storage account of the share                         | False    |               |
+| account_name    | Key of the storage account of the share                          | False    |               |
+| expiration_date | Expiration date in format that can be used by the `date` command | True     | +10 minutes   |
 
 
 **NOTES**:
-1) Expiration date should be in format that can be used by `date` command,
-   see [man 1 date](https://man7.org/linux/man-pages/man1/date.1.html)
+1) For the expiration date format see [man 1 date](https://man7.org/linux/man-pages/man1/date.1.html)
 
 ### Outputs
 | Name                   | Description                                                 |

--- a/README.md
+++ b/README.md
@@ -514,15 +514,18 @@ Generates new temporary
 [Shared Access Signature](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview)
 for a file share, attached to a storage account.
 
-**NOTES**:
-1) The generated SAS is valid for 5 minutes.
-
 ### Inputs
-| Name           | Description                              | Optional |
-|----------------|:-----------------------------------------|----------|
-| directory_name | Path within file share                   | False    |
-| account_key    | Name of the storage account of the share | False    |
-| account_name   | Key of the storage account of the share  | False    |
+| Name            | Description                                                  | Optional | Default Value |
+|-----------------|:-------------------------------------------------------------|----------|---------------|
+| directory_name  | Path within file share                                       | False    |               |
+| account_key     | Name of the storage account of the share                     | False    |               |
+| account_name    | Key of the storage account of the share                      | False    |               |
+| expiration_date | Expiration date in format that can be used by `date` command | True     | +10 minutes   |
+
+
+**NOTES**:
+1) Expiration date should be in format that can be used by `date` command,
+   see [man 1 date](https://man7.org/linux/man-pages/man1/date.1.html)
 
 ### Outputs
 | Name                   | Description                                                 |

--- a/get_azure_share_sas/action.yaml
+++ b/get_azure_share_sas/action.yaml
@@ -19,7 +19,7 @@ inputs:
     required: true
 
   expiration_date:
-    description: expiration date in format that could be used by date --date=... command
+    description: Expiration date in format that can be used by date command
     required: false
     default: "+10 minutes"
 

--- a/get_azure_share_sas/action.yaml
+++ b/get_azure_share_sas/action.yaml
@@ -18,6 +18,11 @@ inputs:
     description: Storage account name
     required: true
 
+  expiration_date:
+    description: expiration date in format that could be used by date --date=... command
+    required: false
+    default: "+10 minutes"
+
 
 outputs:
   authorized_destination:
@@ -34,4 +39,5 @@ runs:
         DIRECTORY_NAME: ${{ inputs.directory_name }}
         ACCOUNT_KEY: ${{ inputs.account_key }}
         ACCOUNT_NAME: ${{ inputs.account_name }}
+        EXPIRATION_DATE: ${{ inputs.expiration_date }}
       id: sas

--- a/get_azure_share_sas/get_azure_share_sas.sh
+++ b/get_azure_share_sas/get_azure_share_sas.sh
@@ -18,8 +18,8 @@ set -Eeuo pipefail
 
 destination="https://$ACCOUNT_NAME.file.core.windows.net/$DIRECTORY_NAME"
 
-echo "Generating SAS for upload to $destination"
-end=$(date -d '+5 minutes' '+%Y-%m-%dT%H:%MZ')
+end=$(date -d "$EXPIRATION_DATE" '+%Y-%m-%dT%H:%MZ')
+echo "Generating SAS for upload to $destination with expiration date $end"
 sas=$(
   az storage account generate-sas \
       --account-key "$ACCOUNT_KEY" \

--- a/get_azure_share_sas/get_azure_share_sas.sh
+++ b/get_azure_share_sas/get_azure_share_sas.sh
@@ -19,7 +19,7 @@ set -Eeuo pipefail
 destination="https://$ACCOUNT_NAME.file.core.windows.net/$DIRECTORY_NAME"
 
 end=$(date -d "$EXPIRATION_DATE" '+%Y-%m-%dT%H:%MZ')
-echo "Generating SAS for upload to $destination with expiration date $end"
+echo "Generating SAS for $destination with expiration date $end"
 sas=$(
   az storage account generate-sas \
       --account-key "$ACCOUNT_KEY" \


### PR DESCRIPTION
Closes #32

## Scope

Implemented:
- Add ability to set expiration date from workflow
- Default expiration date increased from 5 to 10 minutes

Additional changes:
-  Action now logs expiration date of generated SAS token
