### PR TITLE
Added functionality to use azcopy sync and SAS for blobs

### DIFF
--- a/get_azure_share_sas/get_azure_share_sas.sh
+++ b/get_azure_share_sas/get_azure_share_sas.sh
@@ -28,7 +28,7 @@ sas=$(
       --https-only \
       --permissions acdlpruw \
       --resource-types sco \
-      --services f | cut -d'"' -f2
+      --services fb | cut -d'"' -f2
 )
 
 authorized_destination="$destination?$sas"

--- a/run_azcopy/action.yaml
+++ b/run_azcopy/action.yaml
@@ -42,4 +42,6 @@ runs:
       env:
         SOURCE: ${{ inputs.source }}
         TARGET: ${{ inputs.target }}
+        MODE: ${{ inputs.mode }}
         PUT_MD5: ${{ inputs.put_md5 }}
+        DELETE_DESTINATION: ${{ inputs.delete_destination }}

--- a/run_azcopy/action.yaml
+++ b/run_azcopy/action.yaml
@@ -1,5 +1,5 @@
 name: Run azcopy
-description: Copy files with azcopy
+description: Copy/Sync files with azcopy
 
 branding:
   icon: 'battery-charging'
@@ -14,12 +14,24 @@ inputs:
     required: true
     description: Destination directory or SAS token
 
+  mode:
+    required: false
+    default: "copy"
+    description: azcopy action mode (copy or sync)
+
   put_md5:
     required: false
     default: "true"
     description: |
       Create an MD5 hash of each file, and save the hash as the Content-MD5 property
       of the destination blob or file. (By default the hash is NOT created.) Only available when uploading.
+
+  delete_destination:
+    required: false
+    default: "false"
+    description: |
+      When mode="sync", if the 'delete_destination' flag is set to true, then sync will delete files and blobs
+      at the destination that aren't present at the source.
 
 runs:
   using: "composite"

--- a/run_azcopy/run_azcopy.sh
+++ b/run_azcopy/run_azcopy.sh
@@ -21,4 +21,7 @@ AZCOPY_OPTIONS=("--recursive" "--overwrite" "true")
 if [[ "$(echo "$PUT_MD5" | tr '[:upper:]' '[:lower:]')" == 'true' ]]; then
   AZCOPY_OPTIONS+=("--put-md5")
 fi;
-./azcopy copy "$SOURCE" "$TARGET" "${AZCOPY_OPTIONS[@]}"
+if [[ "$(echo "$DELETE_DESTINATION" | tr '[:upper:]' '[:lower:]')" == 'true' ]]; then
+  AZCOPY_OPTIONS+=("--delete-destination" "true")
+fi;
+./azcopy $MODE "$SOURCE" "$TARGET" "${AZCOPY_OPTIONS[@]}"

--- a/run_azcopy/run_azcopy.sh
+++ b/run_azcopy/run_azcopy.sh
@@ -24,4 +24,4 @@ fi;
 if [[ "$(echo "$DELETE_DESTINATION" | tr '[:upper:]' '[:lower:]')" == 'true' ]]; then
   AZCOPY_OPTIONS+=("--delete-destination" "true")
 fi;
-./azcopy $MODE "$SOURCE" "$TARGET" "${AZCOPY_OPTIONS[@]}"
+./azcopy "$MODE" "$SOURCE" "$TARGET" "${AZCOPY_OPTIONS[@]}"


### PR DESCRIPTION
This pull request closes #45.
**Scope:**
To support uploads of static websites to Azure Storage accounts we need two things:
* Alter Get SAS action to include blob service `--service b`
* Alter azcopy action to allow sync like `azcopy sync $source $destination --delete-destination true`

**Implementation notes:**
I've extended the `get_azure_share_sas` action to use `--services fb` rather than `--services f`. This should allow both fileshare and blob actions.  
I've added two parameters to `run_azcopy` action:

1. `mode` which is default `copy` and is used for the `action` argument in `azcopy action --parameters...`
2. `delete_destination` which is default to `false` and adds `--delete-destination true` to parameter if set to `true`.


