### PR TITLE
Remove --overwrite true for azcopy sync

### DIFF
--- a/run_azcopy/run_azcopy.sh
+++ b/run_azcopy/run_azcopy.sh
@@ -17,7 +17,10 @@
 set -Eeuo pipefail
 
 echo "Copy from $SOURCE to $TARGET"
-AZCOPY_OPTIONS=("--recursive" "--overwrite" "true")
+AZCOPY_OPTIONS=("--recursive")
+if [[ "$(echo "$MODE" | tr '[:upper:]' '[:lower:]')" == 'upload' ]]; then
+  AZCOPY_OPTIONS+=("--overwrite" "true")
+fi;
 if [[ "$(echo "$PUT_MD5" | tr '[:upper:]' '[:lower:]')" == 'true' ]]; then
   AZCOPY_OPTIONS+=("--put-md5")
 fi;


### PR DESCRIPTION
```sh
azcopy sync "$source" "$target"
```
Does not support `--overwrite true`