### PR TITLE
Install poetry-plugin-export explicitly in the poetry action

### DIFF
--- a/install_poetry/install_poetry.sh
+++ b/install_poetry/install_poetry.sh
@@ -60,12 +60,11 @@ fi;
 
 if [[ "$(echo "$EXPORT_DEV_REQUIREMENTS" | tr '[:upper:]' '[:lower:]')" == "true" ]];
 then
-  EXPORT_ADDITIONAL_OPTIONS="$EXPORT_ADDITIONAL_OPTIONS --without dev"
+  EXPORT_ADDITIONAL_OPTIONS="$EXPORT_ADDITIONAL_OPTIONS"
 fi;
 
 if [[ "$(echo "$EXPORT_REQUIREMENTS" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
   REQUIREMENTS_ABSOLUTE_PATH="$PWD/$REQUIREMENTS_PATH"
-  poetry self add poetry-plugin-export
   # shellcheck disable=SC2086
   poetry export -f requirements.txt --output "$REQUIREMENTS_ABSOLUTE_PATH" --without-hashes $EXPORT_ADDITIONAL_OPTIONS
   echo "requirements exported to $REQUIREMENTS_ABSOLUTE_PATH"

--- a/install_poetry/install_poetry.sh
+++ b/install_poetry/install_poetry.sh
@@ -65,7 +65,7 @@ fi;
 
 if [[ "$(echo "$EXPORT_REQUIREMENTS" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
   REQUIREMENTS_ABSOLUTE_PATH="$PWD/$REQUIREMENTS_PATH"
-  # poetry self add poetry-plugin-export
+  poetry self add poetry-plugin-export
   # shellcheck disable=SC2086
   poetry export -f requirements.txt --output "$REQUIREMENTS_ABSOLUTE_PATH" --without-hashes $EXPORT_ADDITIONAL_OPTIONS
   echo "requirements exported to $REQUIREMENTS_ABSOLUTE_PATH"

--- a/install_poetry/install_poetry.sh
+++ b/install_poetry/install_poetry.sh
@@ -60,11 +60,12 @@ fi;
 
 if [[ "$(echo "$EXPORT_DEV_REQUIREMENTS" | tr '[:upper:]' '[:lower:]')" == "true" ]];
 then
-  EXPORT_ADDITIONAL_OPTIONS="$EXPORT_ADDITIONAL_OPTIONS"
+  EXPORT_ADDITIONAL_OPTIONS="$EXPORT_ADDITIONAL_OPTIONS --without dev"
 fi;
 
 if [[ "$(echo "$EXPORT_REQUIREMENTS" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
   REQUIREMENTS_ABSOLUTE_PATH="$PWD/$REQUIREMENTS_PATH"
+  poetry self add poetry-plugin-export
   # shellcheck disable=SC2086
   poetry export -f requirements.txt --output "$REQUIREMENTS_ABSOLUTE_PATH" --without-hashes $EXPORT_ADDITIONAL_OPTIONS
   echo "requirements exported to $REQUIREMENTS_ABSOLUTE_PATH"

--- a/install_poetry/install_poetry.sh
+++ b/install_poetry/install_poetry.sh
@@ -26,6 +26,7 @@ fi
 
 curl -sSL https://install.python-poetry.org | python3 -
 export PATH=/github/home/.local/bin:$PATH
+poetry self add poetry-plugin-export
 poetry config repositories.custom_repo "$REPO_URL"
 echo "custom_repo_name=custom_repo" >> "$GITHUB_OUTPUT"
 

--- a/install_poetry/install_poetry.sh
+++ b/install_poetry/install_poetry.sh
@@ -26,7 +26,6 @@ fi
 
 curl -sSL https://install.python-poetry.org | python3 -
 export PATH=/github/home/.local/bin:$PATH
-poetry self add poetry-plugin-export
 poetry config repositories.custom_repo "$REPO_URL"
 echo "custom_repo_name=custom_repo" >> "$GITHUB_OUTPUT"
 
@@ -66,6 +65,7 @@ fi;
 
 if [[ "$(echo "$EXPORT_REQUIREMENTS" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
   REQUIREMENTS_ABSOLUTE_PATH="$PWD/$REQUIREMENTS_PATH"
+  # poetry self add poetry-plugin-export
   # shellcheck disable=SC2086
   poetry export -f requirements.txt --output "$REQUIREMENTS_ABSOLUTE_PATH" --without-hashes $EXPORT_ADDITIONAL_OPTIONS
   echo "requirements exported to $REQUIREMENTS_ABSOLUTE_PATH"


### PR DESCRIPTION
Resolves https://github.com/SneaksAndData/github-actions/issues/37

If poetry removes poetry-plugin-export in the future, we will need to install it explicitly.