### PR TITLE
[BREAKING CHANGE] Add ability to publish packages to public repos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: ./semver_release/
         with:
           major_v: 0
-          minor_v: 0
+          minor_v: 1
       - name: Print version
         run:  "echo \"New version is: ${{ steps.create-release.outputs.version }}\""
         shell: bash

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ COMMENT_NUMBER is number of comment which triggered a build.
 This action relies on git tags to be present in order to generate an artifact tag.
 2) This action should be placed in separate job with issue_comment pull request trigger. (see Usage below)
 3) This action requires to [poetry](https://python-poetry.org/docs/master/) ~1.2 being installed in build environment (for example, by [install_poetry action](#install_poetry))
-4) ⚠️ If the input `public_package_index_token` is provided and `repo_url` is not provided, this action will push the package to a **public repository** (https://pypi.org)
+4) ⚠️ If the input `repo_url` is not provided, this action will push the package to a **public repository** (https://pypi.org).
+In this case, the input `public_package_index_token` should be provided.
 
 ### Inputs
 | Name                       | Description                                                                          | Optional | Default value |

--- a/README.md
+++ b/README.md
@@ -176,15 +176,17 @@ COMMENT_NUMBER is number of comment which triggered a build.
 This action relies on git tags to be present in order to generate an artifact tag.
 2) This action should be placed in separate job with issue_comment pull request trigger. (see Usage below)
 3) This action requires to [poetry](https://python-poetry.org/docs/master/) ~1.2 being installed in build environment (for example, by [install_poetry action](#install_poetry))
+4) ⚠️ If the input `public_package_index_token` is provided and `repo_url` is not provided, this action will push the package to a **public repository** (https://pypi.org)
 
 ### Inputs
-| Name                | Description                                                                          | Optional | Default value  |
-|---------------------|:-------------------------------------------------------------------------------------|----------|:---------------|
-| pypi_repo_url       | Package index URL                                                                    | False    |                |
-| pypi_token_username | Package index authentication username                                                | False    |                |
-| pypi_token          | Package index authentication token or password.                                      | False    |                |
-| package_name        | Name of package to create. This should match name of root project directory          | False    |                |               
-| version             | Version of package. If not provided, a new **development** version will be generated |          | Empty          |               
+| Name                       | Description                                                                          | Optional | Default value |
+|----------------------------|:-------------------------------------------------------------------------------------|----------|:--------------|
+| repo_url                   | Package index URL                                                                    | True     | Empty         |
+| repo_token_username        | Package index authentication username                                                | True     | Empty         |
+| repo_token                 | Package index authentication token or password.                                      | True     | Empty         |
+| package_name               | Name of package to create. This should match name of root project directory          | False    |               |               
+| version                    | Version of package. If not provided, a new **development** version will be generated |          | Empty         |               
+| public_package_index_token | Access token for publishing to a public repository (https://pypi.org)                | True     | Empty         |
 
 ### Outputs
 No outputs defined

--- a/create_package/action.yaml
+++ b/create_package/action.yaml
@@ -6,15 +6,19 @@ branding:
   color: 'green'
 
 inputs:
-  pypi_repo_url:
+  repo_url:
     description: Package index URL.
     required: true
 
-  pypi_token_username:
+  repo_token_username:
     description: Package index authentication username.
     required: true
 
-  pypi_token:
+  repo_token:
+    description: Package index authentication token or password.
+    required: true
+
+  public_package_index_token:
     description: Package index authentication token or password.
     required: true
 
@@ -39,11 +43,11 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/create_package.sh
       env:
-        REPO_URL: ${{ inputs.pypi_repo_url }}
+        REPO_URL: ${{ inputs.repo_url }}
         PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
         COMMENTS_COUNT: ${{ github.event.issue.comments }}
-        POETRY_HTTP_BASIC_CUSTOM_REPO_USERNAME: ${{ inputs.pypi_token_username }}
-        POETRY_HTTP_BASIC_CUSTOM_REPO_PASSWORD: ${{ inputs.pypi_token }}
+        POETRY_HTTP_BASIC_CUSTOM_REPO_USERNAME: ${{ inputs.repo_token_username }}
+        POETRY_HTTP_BASIC_CUSTOM_REPO_PASSWORD: ${{ inputs.repo_token }}
         PACKAGE_NAME: ${{ inputs.package_name }}
         VERSION: ${{ inputs.version }}
       id: package-generator

--- a/create_package/action.yaml
+++ b/create_package/action.yaml
@@ -50,6 +50,7 @@ runs:
         POETRY_HTTP_BASIC_CUSTOM_REPO_PASSWORD: ${{ inputs.repo_token }}
         PACKAGE_NAME: ${{ inputs.package_name }}
         VERSION: ${{ inputs.version }}
+        POETRY_PYPI_TOKEN_PYPI: ${{ inputs.public_package_index_token }}
       id: package-generator
     - name: Create comment
       uses: peter-evans/create-or-update-comment@v2

--- a/create_package/create_package.sh
+++ b/create_package/create_package.sh
@@ -29,10 +29,14 @@ if [[ -n "$REPO_URL" ]]; then
   poetry config repositories.custom_repo "$REPO_URL"
   poetry build && poetry publish -r custom_repo
 else
+   # Turn of built-in check of unbound variables to set
+   # better error message if token is not set
+  set +u
   if [[ -z "$POETRY_PYPI_TOKEN_PYPI" ]]; then
     >&2 echo "the \`public_package_index_token\` should be provided"
     exit 1
   fi;
+  set -u
   echo "PUBLISHING PACKAGE TO PyPI"
   poetry build && poetry publish
 fi;

--- a/create_package/create_package.sh
+++ b/create_package/create_package.sh
@@ -24,7 +24,7 @@ else
 fi;
 sed -i "s/version = \"0.0.0\"/version = \"$version\"/" pyproject.toml
 echo "__version__ = '$version'" > "./$PACKAGE_NAME/_version.py"
-if [[ -z "$REPO_URL" ]]; then
+if [[ -n "$REPO_URL" ]]; then
   echo "REPOSITORY TO PUBLISH IS $REPO_URL"
   poetry config repositories.custom_repo "$REPO_URL"
   poetry build && poetry publish -r custom_repo

--- a/create_package/create_package.sh
+++ b/create_package/create_package.sh
@@ -24,7 +24,17 @@ else
 fi;
 sed -i "s/version = \"0.0.0\"/version = \"$version\"/" pyproject.toml
 echo "__version__ = '$version'" > "./$PACKAGE_NAME/_version.py"
-echo "REPOSITORY TO PUBLISH IS $REPO_URL"
-poetry config repositories.custom_repo "$REPO_URL"
-poetry build && poetry publish -r custom_repo
+if [[ -z "$REPO_URL" ]]; then
+  echo "REPOSITORY TO PUBLISH IS $REPO_URL"
+  poetry config repositories.custom_repo "$REPO_URL"
+  poetry build && poetry publish -r custom_repo
+else
+  if [[ -z "$POETRY_PYPI_TOKEN_PYPI" ]]; then
+    >&2 echo "the \`public_package_index_token\` should be provided"
+    exit 1
+  fi;
+  echo "PUBLISHING PACKAGE TO PyPI"
+  poetry build && poetry publish
+fi;
+
 echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/create_package/create_package.sh
+++ b/create_package/create_package.sh
@@ -29,8 +29,8 @@ if [[ -n "$REPO_URL" ]]; then
   poetry config repositories.custom_repo "$REPO_URL"
   poetry build && poetry publish -r custom_repo
 else
-   # Turn of built-in check of unbound variables to set
-   # better error message if token is not set
+   # Turn of the built-in check of unbound variables to display
+   # a more informative error message if a token was not provided
   set +u
   if [[ -z "$POETRY_PYPI_TOKEN_PYPI" ]]; then
     >&2 echo "the \`public_package_index_token\` should be provided"


### PR DESCRIPTION
Resolves https://github.com/SneaksAndData/esd-services-api-client/issues/59

**Note**: this pull request contains **braking changes** in the **create_package** action:
- Input `pypi_repo_url `renamed to `repo_url`
- Input `pypi_token_username` renamed to `repo_token_username`
- Input `pypi_token` renamed to `repo_token`


Implemented:
- Added input public_package_index_token for publishing to public repository (https://pypi.org)